### PR TITLE
chore: bump version to 5.0.3 in package.json and enhance OpenAPI spec…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-sync",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A powerful developer tool that automates API documentation synchronization with your codebase using OpenAPI specifications. Generates TypeScript types, fully-typed API clients (Fetch, Axios, React Query, SWR, RTK Query), endpoint definitions, runtime validation schemas (Zod, Yup, Joi), and comprehensive documentation with enterprise-grade reliability",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
… handling

- Updated version number in package.json to 5.0.3.
- Improved documentation for the apiUrl parameter to clarify support for local file paths.
- Added functionality to fetch OpenAPI specs from local files or URLs, enhancing flexibility in spec handling.
- Introduced a helper function to streamline schema processing for both OpenAPI 3.x components and Swagger 2.0 definitions.